### PR TITLE
Fix for end-of-word throwing NPE when at the end of a buffer

### DIFF
--- a/src/dk/salza/liq/slider.clj
+++ b/src/dk/salza/liq/slider.clj
@@ -571,8 +571,8 @@
 
 (defn end-of-word
   [sl]
-  (let [iswhite (fn [c] (re-matches #"\s" c))
-        isalphanum (fn [c] (re-matches #"(\p{L}|\d)" c))
+  (let [iswhite (fn [c] (and c (re-matches #"\s" c)))
+        isalphanum (fn [c] (and c (re-matches #"(\p{L}|\d)" c)))
         issym (fn [c] (not (or (iswhite c) (isalphanum c))))
         sl0 (right-until (right sl) (comp not iswhite))
         c0 (get-char sl0)

--- a/test/dk/salza/liq/slider_test.clj
+++ b/test/dk/salza/liq/slider_test.clj
@@ -27,7 +27,7 @@
 
 (defn random-textoperation
   [sl]
-  (let [r (rand-int 11)]
+  (let [r (rand-int 12)]
     (cond (= r 0) (right sl 1)
           (= r 1) (right sl (rand-int 20))
           (= r 2) (left sl 1)
@@ -35,8 +35,9 @@
           (= r 4) (delete sl 1)
           (= r 5) (delete sl (rand-int 3))
           (= r 6) (end-of-line sl)
-          (= r 7) (beginning sl)
-          (= r 8) (set-meta sl :something "abc")
+          (= r 7) (end-of-word sl)
+          (= r 8) (beginning sl)
+          (= r 9) (set-meta sl :something "abc")
           :else (insert sl (random-string (rand-int 100))))))
 
 (defn generate


### PR DESCRIPTION
Hi! With cursor at the end of a buffer, running end-of-word caused the editor to crash.  Here's a potential fix.