### PR TITLE
writing file in nonexistant directory now creates directory.

### DIFF
--- a/src/liq/util.cljc
+++ b/src/liq/util.cljc
@@ -111,6 +111,7 @@
 
 (defn write-file
   [path content]
+  (io/make-parents path)
   (spit path content))
 
 (defn eval-safe


### PR DESCRIPTION
Tentative solution to https://github.com/mogenslund/liquid/issues/48#issue-621300411
IMHO it's better than having the editor crash.